### PR TITLE
Fix ExcelPersonParser to parse headers dynamically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ch.martinelli.oss</groupId>
     <artifactId>registration</artifactId>
-    <version>1.11.0</version>
+    <version>1.11.1-SNAPSHOT</version>
 
     <name>registration</name>
     <description>Simple Event Registration App</description>

--- a/src/main/java/ch/martinelli/oss/registration/domain/ExcelPersonParser.java
+++ b/src/main/java/ch/martinelli/oss/registration/domain/ExcelPersonParser.java
@@ -9,30 +9,37 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility class to parse person data from Excel files. Expected Excel format: - First row
  * is header - Columns: MITGLIEDERNR, VORNAME, NACHNAME, STRASSE, PLZ, ORT, EMAIL, EMAIL
  * ALTERNATIV, KATEGORIE, ZUSATZ, RIEGEN
+ * <p>
+ * The parser reads the header row to determine column positions dynamically, allowing
+ * columns to be in any order.
  */
 public class ExcelPersonParser {
 
-    private static final int COL_MEMBER_ID = 0;
+    // Expected header names (case-insensitive)
+    private static final String HEADER_MEMBER_ID = "MITGLIEDERNR";
 
-    private static final int COL_FIRST_NAME = 1;
+    private static final String HEADER_FIRST_NAME = "VORNAME";
 
-    private static final int COL_LAST_NAME = 2;
+    private static final String HEADER_LAST_NAME = "NACHNAME";
 
-    private static final int COL_EMAIL = 6;
+    private static final String HEADER_EMAIL = "EMAIL";
 
-    private static final int COL_EMAIL_ALT = 7;
+    private static final String HEADER_EMAIL_ALT = "EMAIL ALTERNATIV";
 
     /**
      * Parse Excel file and extract person data.
      * @param inputStream Excel file input stream
      * @return List of parsed person data
      * @throws IOException if file cannot be read or is invalid
+     * @throws IllegalArgumentException if required headers are missing
      */
     public List<ExcelPersonData> parseExcelFile(InputStream inputStream) throws IOException {
         List<ExcelPersonData> persons = new ArrayList<>();
@@ -40,14 +47,28 @@ public class ExcelPersonParser {
         try (var workbook = new XSSFWorkbook(inputStream)) {
             var sheet = workbook.getSheetAt(0);
 
-            // Skip header row (row 0)
+            // Parse header row to determine column positions
+            var headerRow = sheet.getRow(0);
+            if (headerRow == null) {
+                return persons; // Empty sheet
+            }
+
+            var columnMap = parseHeaderRow(headerRow);
+
+            // Validate required columns exist
+            if (!columnMap.containsKey(HEADER_FIRST_NAME) || !columnMap.containsKey(HEADER_LAST_NAME)) {
+                throw new IllegalArgumentException(
+                        "Required headers missing. Expected: " + HEADER_FIRST_NAME + ", " + HEADER_LAST_NAME);
+            }
+
+            // Parse data rows (starting from row 1)
             for (var i = 1; i <= sheet.getLastRowNum(); i++) {
                 var row = sheet.getRow(i);
                 if (row == null || isRowEmpty(row)) {
                     continue;
                 }
 
-                var personData = parseRow(row);
+                var personData = parseRow(row, columnMap);
                 if (personData != null) {
                     persons.add(personData);
                 }
@@ -62,29 +83,60 @@ public class ExcelPersonParser {
      * @param data Excel file as byte array
      * @return List of parsed person data
      * @throws IOException if file cannot be read or is invalid
+     * @throws IllegalArgumentException if required headers are missing
      */
     public List<ExcelPersonData> parseExcelFile(byte[] data) throws IOException {
         return parseExcelFile(new ByteArrayInputStream(data));
     }
 
-    private ExcelPersonData parseRow(Row row) {
+    /**
+     * Parse header row and create a map of column names to indices.
+     * @param headerRow The header row from the Excel sheet
+     * @return Map of normalized column names to column indices
+     */
+    private Map<String, Integer> parseHeaderRow(Row headerRow) {
+        Map<String, Integer> columnMap = new HashMap<>();
+
+        for (var i = 0; i < headerRow.getLastCellNum(); i++) {
+            var cell = headerRow.getCell(i);
+            if (cell != null) {
+                var headerName = getCellValueAsString(cell);
+                if (headerName != null && !headerName.isBlank()) {
+                    // Normalize: uppercase and trim
+                    var normalizedName = headerName.toUpperCase().trim();
+                    columnMap.put(normalizedName, i);
+                }
+            }
+        }
+
+        return columnMap;
+    }
+
+    private ExcelPersonData parseRow(Row row, Map<String, Integer> columnMap) {
         // Extract member ID (numeric in Excel, convert to Integer)
         Integer memberId = null;
-        var memberIdCell = row.getCell(COL_MEMBER_ID);
-        if (memberIdCell != null && memberIdCell.getCellType() == CellType.NUMERIC) {
-            memberId = (int) memberIdCell.getNumericCellValue();
+        var memberIdIndex = columnMap.get(HEADER_MEMBER_ID);
+        if (memberIdIndex != null) {
+            var memberIdCell = row.getCell(memberIdIndex);
+            if (memberIdCell != null && memberIdCell.getCellType() == CellType.NUMERIC) {
+                memberId = (int) memberIdCell.getNumericCellValue();
+            }
         }
 
         // Extract first name
-        var firstName = getCellValueAsString(row.getCell(COL_FIRST_NAME));
+        var firstNameIndex = columnMap.get(HEADER_FIRST_NAME);
+        var firstName = firstNameIndex != null ? getCellValueAsString(row.getCell(firstNameIndex)) : null;
 
         // Extract last name
-        var lastName = getCellValueAsString(row.getCell(COL_LAST_NAME));
+        var lastNameIndex = columnMap.get(HEADER_LAST_NAME);
+        var lastName = lastNameIndex != null ? getCellValueAsString(row.getCell(lastNameIndex)) : null;
 
         // Extract email (prefer EMAIL, fall back to EMAIL ALTERNATIV)
-        var email = getCellValueAsString(row.getCell(COL_EMAIL));
+        var emailIndex = columnMap.get(HEADER_EMAIL);
+        var email = emailIndex != null ? getCellValueAsString(row.getCell(emailIndex)) : null;
         if (email == null || email.isBlank()) {
-            email = getCellValueAsString(row.getCell(COL_EMAIL_ALT));
+            var emailAltIndex = columnMap.get(HEADER_EMAIL_ALT);
+            email = emailAltIndex != null ? getCellValueAsString(row.getCell(emailAltIndex)) : null;
         }
 
         // Skip rows without required fields

--- a/src/test/java/ch/martinelli/oss/registration/domain/ExcelPersonParserTest.java
+++ b/src/test/java/ch/martinelli/oss/registration/domain/ExcelPersonParserTest.java
@@ -599,4 +599,192 @@ class ExcelPersonParserTest {
         }
     }
 
+    // ========== Header Parsing Tests ==========
+
+    @Test
+    void shouldParseExcelFileWithReorderedColumns() throws IOException {
+        // Given - columns in different order than expected
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        // Reorder: EMAIL, NACHNAME, VORNAME, MITGLIEDERNR
+        headerRow.createCell(0).setCellValue("EMAIL");
+        headerRow.createCell(1).setCellValue("NACHNAME");
+        headerRow.createCell(2).setCellValue("VORNAME");
+        headerRow.createCell(3).setCellValue("MITGLIEDERNR");
+
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("john@example.com");
+        row.createCell(1).setCellValue("Doe");
+        row.createCell(2).setCellValue("John");
+        row.createCell(3).setCellValue(123);
+
+        var bytes = workbookToBytes(workbook);
+
+        // When
+        var persons = parser.parseExcelFile(bytes);
+
+        // Then
+        assertThat(persons).hasSize(1);
+        assertThat(persons.getFirst().memberId()).isEqualTo(123);
+        assertThat(persons.getFirst().firstName()).isEqualTo("John");
+        assertThat(persons.getFirst().lastName()).isEqualTo("Doe");
+        assertThat(persons.getFirst().email()).isEqualTo("john@example.com");
+    }
+
+    @Test
+    void shouldThrowExceptionForMissingRequiredHeaders() throws IOException {
+        // Given - missing VORNAME (first name) column
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("MITGLIEDERNR");
+        headerRow.createCell(1).setCellValue("NACHNAME"); // Missing VORNAME
+        headerRow.createCell(2).setCellValue("EMAIL");
+
+        var bytes = workbookToBytes(workbook);
+
+        // When/Then
+        assertThatThrownBy(() -> parser.parseExcelFile(bytes)).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Required headers missing")
+            .hasMessageContaining("VORNAME");
+    }
+
+    @Test
+    void shouldThrowExceptionForMissingLastNameHeader() throws IOException {
+        // Given - missing NACHNAME (last name) column
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("MITGLIEDERNR");
+        headerRow.createCell(1).setCellValue("VORNAME");
+        headerRow.createCell(2).setCellValue("EMAIL"); // Missing NACHNAME
+
+        var bytes = workbookToBytes(workbook);
+
+        // When/Then
+        assertThatThrownBy(() -> parser.parseExcelFile(bytes)).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Required headers missing")
+            .hasMessageContaining("NACHNAME");
+    }
+
+    @Test
+    void shouldIgnoreExtraUnknownColumns() throws IOException {
+        // Given - includes extra columns not used by parser
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("VORNAME");
+        headerRow.createCell(1).setCellValue("NACHNAME");
+        headerRow.createCell(2).setCellValue("EXTRA_COLUMN"); // Extra column
+        headerRow.createCell(3).setCellValue("ANOTHER_EXTRA"); // Another extra column
+        headerRow.createCell(4).setCellValue("EMAIL");
+
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("John");
+        row.createCell(1).setCellValue("Doe");
+        row.createCell(2).setCellValue("Ignored");
+        row.createCell(3).setCellValue("Also Ignored");
+        row.createCell(4).setCellValue("john@example.com");
+
+        var bytes = workbookToBytes(workbook);
+
+        // When
+        var persons = parser.parseExcelFile(bytes);
+
+        // Then
+        assertThat(persons).hasSize(1);
+        assertThat(persons.getFirst().firstName()).isEqualTo("John");
+        assertThat(persons.getFirst().lastName()).isEqualTo("Doe");
+        assertThat(persons.getFirst().email()).isEqualTo("john@example.com");
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveHeaders() throws IOException {
+        // Given - headers in different cases
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("vorname"); // lowercase
+        headerRow.createCell(1).setCellValue("NachName"); // mixed case
+        headerRow.createCell(2).setCellValue("EMAIL"); // uppercase
+        headerRow.createCell(3).setCellValue("MitgliederNr"); // mixed case
+
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("John");
+        row.createCell(1).setCellValue("Doe");
+        row.createCell(2).setCellValue("john@example.com");
+        row.createCell(3).setCellValue(123);
+
+        var bytes = workbookToBytes(workbook);
+
+        // When
+        var persons = parser.parseExcelFile(bytes);
+
+        // Then
+        assertThat(persons).hasSize(1);
+        assertThat(persons.getFirst().firstName()).isEqualTo("John");
+        assertThat(persons.getFirst().lastName()).isEqualTo("Doe");
+        assertThat(persons.getFirst().email()).isEqualTo("john@example.com");
+        assertThat(persons.getFirst().memberId()).isEqualTo(123);
+    }
+
+    @Test
+    void shouldHandleHeadersWithExtraWhitespace() throws IOException {
+        // Given - headers with leading/trailing whitespace
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("  VORNAME  "); // extra spaces
+        headerRow.createCell(1).setCellValue("\tNACHNAME\t"); // tabs
+        headerRow.createCell(2).setCellValue(" EMAIL "); // spaces
+        headerRow.createCell(3).setCellValue("EMAIL ALTERNATIV  "); // trailing spaces
+
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("John");
+        row.createCell(1).setCellValue("Doe");
+        row.createCell(2).setCellValue(""); // blank primary email
+        row.createCell(3).setCellValue("john.alt@example.com");
+
+        var bytes = workbookToBytes(workbook);
+
+        // When
+        var persons = parser.parseExcelFile(bytes);
+
+        // Then
+        assertThat(persons).hasSize(1);
+        assertThat(persons.getFirst().firstName()).isEqualTo("John");
+        assertThat(persons.getFirst().lastName()).isEqualTo("Doe");
+        assertThat(persons.getFirst().email()).isEqualTo("john.alt@example.com"); // Falls
+                                                                                  // back
+                                                                                  // to
+                                                                                  // alternate
+    }
+
+    @Test
+    void shouldHandleMinimalColumnsInAnyOrder() throws IOException {
+        // Given - only required columns (VORNAME, NACHNAME), no optional columns
+        var workbook = new XSSFWorkbook();
+        var sheet = workbook.createSheet("Sheet1");
+        var headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("NACHNAME");
+        headerRow.createCell(1).setCellValue("VORNAME");
+
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("Doe");
+        row.createCell(1).setCellValue("John");
+
+        var bytes = workbookToBytes(workbook);
+
+        // When
+        var persons = parser.parseExcelFile(bytes);
+
+        // Then
+        assertThat(persons).hasSize(1);
+        assertThat(persons.getFirst().firstName()).isEqualTo("John");
+        assertThat(persons.getFirst().lastName()).isEqualTo("Doe");
+        assertThat(persons.getFirst().email()).isNull();
+        assertThat(persons.getFirst().memberId()).isNull();
+    }
+
 }


### PR DESCRIPTION
## Summary
Fixes bug where ExcelPersonParser used hard-coded column positions instead of reading header row names, making it fragile to column reordering.

## Problem
The parser previously used fixed column indices (0, 1, 2, 6, 7) which meant:
- If Excel columns were reordered, parsing would fail silently or produce incorrect data
- The parser was unnecessarily rigid and error-prone

## Solution
Refactored to read the header row dynamically:
- Added `parseHeaderRow()` method to build a `Map<String, Integer>` of column names → indices
- Headers are matched case-insensitively with whitespace trimming
- Validates required headers (VORNAME, NACHNAME) exist and throws clear errors if missing
- Updated `parseRow()` to use dynamic column indices from the header map

## Changes
- **ExcelPersonParser.java**: Added dynamic header parsing logic
- **ExcelPersonParserTest.java**: Added 7 comprehensive test cases:
  - Reordered columns
  - Missing required headers (VORNAME and NACHNAME)
  - Extra/unknown columns (should be ignored)
  - Case-insensitive header matching
  - Headers with extra whitespace
  - Minimal columns in any order

## Test Plan
- [x] All 32 tests pass (25 existing + 7 new)
- [x] Code formatting applied with spring-javaformat
- [x] Backward compatible with existing Excel files
- [x] Clear error messages when required headers are missing

## Benefits
- Robust against column reordering in Excel files
- Better error messages for users
- Maintains backward compatibility
- More flexible for different Excel layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)